### PR TITLE
Add git to apt package list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sh -c "$(wget https://raw.githubusercontent.com/Eeems-Org/remarkable-debian-chro
 
 ```
 # Install prerequisites
-apt install meson gcc cmake make libdrm-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev pkg-config libpng-dev
+apt install git meson gcc cmake make libdrm-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev pkg-config libpng-dev
 git clone https://gitlab.freedesktop.org/mesa/kmscube.git
 cd kmscube
 


### PR DESCRIPTION
I'm guessing you wrote up this README based on a device that you'd been working with for a while, and just missed this. `git` isn't installed by default, when you first enter the chroot. I've prepended it to the list of packages to install.

I went through the instructions on a brand new device, freshly updated and with dev mode enabled. That was the only thing that didn't work as expected :)